### PR TITLE
Allow connections returned by go-stun to be used (for hole-punching, etc).

### DIFF
--- a/stun/agent.go
+++ b/stun/agent.go
@@ -104,6 +104,7 @@ func (a *Agent) ServeConn(c net.Conn) error {
 	for {
 		select {
 		case <-a.stopCh:
+			c.SetReadDeadline(time.Time{}) // reset read deadline
 			return nil
 		default:
 			if p >= len(b) {
@@ -143,11 +144,12 @@ func (a *Agent) Stop() {
 func (a *Agent) ServePacket(c net.PacketConn) error {
 	b := getBuffer()
 	defer putBuffer(b)
-	defer c.Close()
+	// defer c.Close()
 
 	for {
 		select {
 		case <-a.stopCh:
+			c.SetReadDeadline(time.Time{}) // reset read deadline
 			return nil
 		default:
 			c.SetReadDeadline(time.Now().Add(50 * time.Millisecond))

--- a/stun/agent.go
+++ b/stun/agent.go
@@ -104,6 +104,8 @@ func (a *Agent) ServeConn(c net.Conn) error {
 	for {
 		select {
 		case <-a.stopCh:
+			// stop muxes
+			a.m.Close()
 			c.SetReadDeadline(time.Time{}) // reset read deadline
 			return nil
 		default:

--- a/stun/stun.go
+++ b/stun/stun.go
@@ -19,6 +19,7 @@ func DiscoverConn(stunAddr string, c *net.UDPConn) (*net.UDPAddr, error) {
 		return nil, err
 	}
 	conn := NewConn(&packetConn{c, stunUDPAddr}, nil)
+
 	addr, err := conn.Discover()
 	if err != nil {
 		conn.Close()

--- a/stun/stun.go
+++ b/stun/stun.go
@@ -19,7 +19,7 @@ func Discover(uri string) (net.PacketConn, net.Addr, error) {
 		conn.Close()
 		return nil, nil, err
 	}
-	// TODO: hijack
+	conn.agent.Stop() // stop the agent's read loop
 	return conn.Conn.(net.PacketConn), addr, nil
 }
 

--- a/stun/stun.go
+++ b/stun/stun.go
@@ -9,6 +9,25 @@ import (
 	"strings"
 )
 
+// DiscoverConn allows discovery using an existing net.UDPConn, which is
+// temporarily hijacked to communicate with the STUN server. The net.UDPConn
+// is returned upon completion of the discovery process, or closed if an error
+// occurs.
+func DiscoverConn(stunAddr string, c *net.UDPConn) (*net.UDPAddr, error) {
+	stunUDPAddr, err := net.ResolveUDPAddr("udp", stunAddr)
+	if err != nil {
+		return nil, err
+	}
+	conn := NewConn(&packetConn{c, stunUDPAddr}, nil)
+	addr, err := conn.Discover()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	conn.agent.Stop() // stop the agent's read loop, relinquishing the conn
+	return addr.(*net.UDPAddr), nil
+}
+
 func Discover(uri string) (net.PacketConn, net.Addr, error) {
 	conn, err := Dial(uri, nil)
 	if err != nil {

--- a/stun/stun_test.go
+++ b/stun/stun_test.go
@@ -1,0 +1,22 @@
+package stun
+
+import (
+	"net"
+	"testing"
+)
+
+func TestDiscoverConn(t *testing.T) {
+	conn, err := net.ListenUDP("udp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr, err := DiscoverConn("stun.l.google.com:19302", conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if addr == nil {
+		t.Fatal("addr not determined")
+	}
+}

--- a/stun/stun_test.go
+++ b/stun/stun_test.go
@@ -3,9 +3,13 @@ package stun
 import (
 	"net"
 	"testing"
+	"time"
 )
 
 func TestDiscoverConn(t *testing.T) {
+	config := DefaultConfig
+	config.RetransmissionTimeout = 300 * time.Millisecond
+	config.TransactionTimeout = time.Second
 	conn, err := net.ListenUDP("udp", nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Per [my earlier comment](https://github.com/pixelbender/go-stun/issues/6#issuecomment-331770216), `go-stun` was not properly relinquishing control over connections returned by `stun.Discover()` -- the `Agent` readloop was still active, which was intercepting all messages sent to the socket.

For me, this set of changes fixed the issue. It introduces a very simple `Stop` method on the `Agent`, which pushes a struct to a channel that either of the Agent read loops may `select` to exit the read loop, effectively relinquishing the connection.

Tests (such as they are) still pass. I'm not sure this is the best/most complete solution, but it made this library usable for me.